### PR TITLE
Copied over repo (without Git history)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,80 @@
+# Wharf API Go client changelog
+
+This project tries to follow [SemVer 2.0.0](https://semver.org/).
+
+<!--
+	When composing new changes to this list, try to follow convention.
+
+	The WIP release shall be updated just before adding the Git tag.
+	From (WIP) to (YYYY-MM-DD), ex: (2021-02-09) for 9th of Febuary, 2021
+
+	A good source on conventions can be found here:
+	https://changelog.md/
+-->
+
+## v1.2.0 (2021-02-25)
+
+- Added CHANGELOG.md to repository. (!10)
+
+- Added support for endpoint `PUT /api/build/{buildid}?status={status}` (via function `PutStatus`). (!11)
+
+- Added support for endpoint `POST /api/build/{buildid}/log` (via function `PostLog`). (!11)
+
+## v1.1.0 (2021-01-07)
+
+- Fixed all endpoint functions not checking status code on HTTP responses. (!9)
+
+## v1.0.0 (2020-12-02)
+
+- Changed package name from `client` to `wharf` and changed the type name
+  `WharfClient` to just `Client`, resulting in usage changing from
+  `client.WharfClient` to `wharf.Client`. (!7, !8)
+
+## v0.1.5 (2020-11-24)
+
+- Removed group endpoints support, a reflection of the changes from the API
+  v1.0.0. (!6)
+  - `GET /api/group` (via `GetGroupById`)
+  - `GET /api/groups/search` (via `GetGroup`)
+  - `PUT /api/group` (via `PutGroup`)
+
+## v0.1.4 (2020-10-23)
+
+- Added support for endpoint `PUT /api/branches` (via function `PutBranches`)
+  that was introduced in the API v1.0.0. (!5)
+
+- Added `README.md` to document that this package is only meant to be used to
+  talk to the main API and not to the provider/plugin APIs just to avoid
+  circular dependencies. (!3)
+
+## v0.1.3 (2020-04-30)
+
+- Added support for endpoint `POST /api/project/{projectid}/{stage}/run`
+  (via `PostProjectRun` function). (!1)
+
+## v0.1.2 (2019-11-21)
+
+- Fixed `/api/providers/search` function (`GetProvider`) to only filter by
+  token ID `if tokenID > 0`. (a57a10d2)
+
+## v0.1.1 (2019-11-21)
+
+- Changed module name and moved repository from `/tools/wharf-project/client`
+  to `/tools/wharf-client` due to restrictions in how Go handles Git paths.
+  (755a2fc4)
+
+## v0.1.0 (2019-11-21)
+
+- Added initial commit. Endpoints supported: (df25308e)
+  - `POST /api/branch` (via `PutBranch`)
+  - `GET /api/group/{groupId}` (via `GetGroupById`)
+  - `GET /api/groups/search` (via `GetGroup`)
+  - `PUT /api/group` (via `PutGroup`)
+  - `GET /api/project/{projectId}` (via `GetProjectById`)
+  - `PUT /api/project` (via `PutProject`)
+  - `GET /api/provider/{providerId}` (via `GetProviderById`)
+  - `POST /api/providers/search` (via `GetProvider`)
+  - `POST /api/provider` (via `PostProvider`)
+  - `GET /api/token/{tokenId}` (via `GetTokenById`)
+  - `POST /api/tokens/search` (via `GetToken`)
+  - `POST /api/token` (via `PostToken`)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Go-lang RPC client for Wharf
+
+A library to talk to Wharf via Wharf's main API written in Go.
+
+Uses `net/http` to send HTTP requests and `encoding/json` to
+serialize/deserialize each message back and forth.
+
+This project is for example used inside the providers to create projects
+into the database when importing from GitLab, GitHub, or Azure DevOps.
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/iver-wharf/wharf-api-client-go/pkg/wharfapi"
+)
+
+func main() {
+	client := wharfapi.Client{
+		ApiUrl:     "https://example.wharf.com",
+		AuthHeader: "Bearer some-auth-token",
+	}
+
+	project,err := client.GetProjectById(125)
+
+	if err != nil {
+		fmt.Printf("Unable to find project\n")
+	} else {
+		fmt.Printf("Project #%d: %s\n", project.ProjectID, project.Name)
+	}
+}
+```
+
+### Sample output
+
+```
+GET | PROJECT | 125
+Project #125: MyProject
+```
+
+---
+
+Maintained by [Iver](https://www.iver.com/en).
+Licensed under the [MIT license](./LICENSE).

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/iver-wharf/wharf-api-client-go
+
+go 1.13
+
+require (
+	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.2.2
+	gopkg.in/guregu/null.v4 v4.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/guregu/null.v4 v4.0.0 h1:1Wm3S1WEA2I26Kq+6vcW+w0gcDo44YKYD7YIEJNHDjg=
+gopkg.in/guregu/null.v4 v4.0.0/go.mod h1:YoQhUrADuG3i9WqesrCmpNRwm1ypAgSHYqoOcTu/JrI=

--- a/pkg/wharfapi/branch.go
+++ b/pkg/wharfapi/branch.go
@@ -1,0 +1,62 @@
+package wharfapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type Branch struct {
+	BranchID  uint   `json:"branchId"`
+	ProjectID uint   `json:"projectId"`
+	Name      string `json:"name"`
+	TokenID   uint   `json:"tokenId"`
+	Default   bool   `json:"default"`
+}
+
+func (c Client) PutBranch(branch Branch) (Branch, error) {
+	newBranch := Branch{}
+
+	body, err := json.Marshal(branch)
+	if err != nil {
+		return newBranch, err
+	}
+
+	url := fmt.Sprintf("%s/api/branch", c.ApiUrl)
+	ioBody, err := doRequest("POST | BRANCH |", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return newBranch, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newBranch)
+	if err != nil {
+		return newBranch, err
+	}
+
+	return newBranch, nil
+}
+
+func (c Client) PutBranches(branches []Branch) ([]Branch, error) {
+	var newBranches []Branch
+	body, err := json.Marshal(branches)
+	if err != nil {
+		return newBranches, err
+	}
+
+	url := fmt.Sprintf("%s/api/branches", c.ApiUrl)
+	ioBody, err := doRequest("PUT | BRANCHES |", http.MethodPut, url, body, c.AuthHeader)
+	if err != nil {
+		return newBranches, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newBranches)
+	if err != nil {
+		return newBranches, err
+	}
+
+	return newBranches, nil
+}

--- a/pkg/wharfapi/build.go
+++ b/pkg/wharfapi/build.go
@@ -1,0 +1,27 @@
+package wharfapi
+
+import (
+	"time"
+
+	"gopkg.in/guregu/null.v4"
+)
+
+type Build struct {
+	BuildID     uint         `json:"buildId"`
+	StatusID    BuildStatus  `json:"statusId"`
+	ProjectID   uint         `json:"projectId"`
+	ScheduledOn *time.Time   `json:"scheduledOn"`
+	StartedOn   *time.Time   `json:"startedOn"`
+	CompletedOn *time.Time   `json:"finishedOn"`
+	GitBranch   string       `json:"gitBranch"`
+	Environment null.String  `json:"environment"`
+	Stage       string       `json:"stage"`
+	Params      []BuildParam `json:"params"`
+	IsInvalid   bool         `json:"isInvalid"`
+}
+
+type BuildParam struct {
+	BuildID      uint   `json:"buildId"`
+	Name         string `json:"name"`
+	Value        string `json:"value"`
+}

--- a/pkg/wharfapi/buildlog.go
+++ b/pkg/wharfapi/buildlog.go
@@ -1,0 +1,47 @@
+package wharfapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type BuildLog struct {
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func (c Client) PostLog(buildID uint, buildLog BuildLog) error {
+	body, err := json.Marshal(buildLog)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/api/build/%d/log", c.ApiUrl, buildID)
+	_, err = doRequest("POST | LOG", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c Client) PutStatus(buildID uint, statusID BuildStatus) (Build, error) {
+	uri := fmt.Sprintf("%s/api/build/%d?status=%s", c.ApiUrl, buildID, url.QueryEscape(statusID.String()))
+
+	ioBody, err := doRequest("PUT | STATUS", http.MethodPut, uri, nil, c.AuthHeader)
+	if err != nil {
+		return Build{}, err
+	}
+	defer (*ioBody).Close()
+
+	build := Build{}
+	err = json.NewDecoder(*ioBody).Decode(&build)
+	if err != nil {
+		return Build{}, err
+	}
+
+	return build, nil
+}

--- a/pkg/wharfapi/buildstatus.go
+++ b/pkg/wharfapi/buildstatus.go
@@ -1,0 +1,27 @@
+package wharfapi
+
+import "strconv"
+
+type BuildStatus int
+
+const (
+	BuildScheduling = BuildStatus(iota)
+	BuildRunning
+	BuildCompleted
+	BuildFailed
+)
+
+func (bs BuildStatus) String() string {
+	switch bs {
+	case BuildScheduling:
+		return "Scheduling"
+	case BuildRunning:
+		return "Running"
+	case BuildCompleted:
+		return "Completed"
+	case BuildFailed:
+		return "Failed"
+	default:
+		return strconv.Itoa(int(bs))
+	}
+}

--- a/pkg/wharfapi/client.go
+++ b/pkg/wharfapi/client.go
@@ -1,0 +1,22 @@
+package wharfapi
+
+type AuthError struct {
+	Realm string
+}
+
+func (e *AuthError) Error() string {
+	return e.Realm
+}
+
+// WharfClient contains authentication and API URLs used to access
+// the Wharf main API.
+type Client struct {
+	AuthHeader string
+	ApiUrl     string
+}
+
+// WharfClient contains authentication and API URLs used to access
+// the Wharf main API.
+//
+// Deprecated: This type has been renamed to Client and may be removed in a future release.
+type WharfClient Client

--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -1,0 +1,104 @@
+package wharfapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Project struct {
+	ProjectID       uint   `json:"projectId"`
+	Name            string `json:"name"`
+	GroupName       string `json:"groupName"`
+	BuildDefinition string `json:"buildDefinition"`
+	TokenID         uint   `json:"tokenId"`
+	Description     string `json:"description"`
+	AvatarUrl       string `json:"avatarUrl"`
+	ProviderID      uint   `json:"providerId"`
+	GitURL          string `json:"gitUrl"`
+}
+
+type ProjectRun struct {
+	ProjectID   uint   `json:"projectId"`
+	Stage       string `json:"stage"`
+	Branch      string `json:"branch"`
+	Environment string `json:"environment"`
+}
+
+type ProjectRunResponse struct {
+	BuildId uint `json:"buildRef"`
+}
+
+func (c Client) GetProjectById(projectID uint) (Project, error) {
+	url := fmt.Sprintf("%s/api/project/%v", c.ApiUrl, projectID)
+	ioBody, err := doRequest("GET | PROJECT |", http.MethodGet, url, []byte{}, c.AuthHeader)
+	if err != nil {
+		return Project{}, err
+	}
+
+	defer (*ioBody).Close()
+
+	newProject := Project{}
+	err = json.NewDecoder(*ioBody).Decode(&newProject)
+	if err != nil {
+		return Project{}, err
+	}
+	return newProject, nil
+}
+
+func (c Client) PutProject(project Project) (Project, error) {
+	body, err := json.Marshal(project)
+	if err != nil {
+		return Project{}, err
+	}
+
+	log.WithField("project", string(body)).Traceln()
+
+	url := fmt.Sprintf("%s/api/project", c.ApiUrl)
+	ioBody, err := doRequest("PUT | PROJECT |", http.MethodPut, url, body, c.AuthHeader)
+	if err != nil {
+		return Project{}, err
+	}
+
+	defer (*ioBody).Close()
+
+	newProject := Project{}
+	err = json.NewDecoder(*ioBody).Decode(&newProject)
+	if err != nil {
+		return Project{}, err
+	}
+
+	return newProject, nil
+}
+
+func (c Client) PostProjectRun(projectRun ProjectRun) (ProjectRunResponse, error) {
+	body, err := json.Marshal(projectRun)
+	if err != nil {
+		return ProjectRunResponse{}, err
+	}
+
+	url := fmt.Sprintf(
+		"%s/api/project/%d/%s/run?branch=%s&environment=%s",
+		c.ApiUrl,
+		projectRun.ProjectID,
+		projectRun.Stage,
+		projectRun.Branch,
+		projectRun.Environment)
+	ioBody, err := doRequest("POST | PROJECT RUN |", http.MethodPut, url, body, c.AuthHeader)
+	if err != nil {
+		return ProjectRunResponse{}, err
+	}
+
+	defer (*ioBody).Close()
+
+	newProject := ProjectRunResponse{}
+	err = json.NewDecoder(*ioBody).Decode(&newProject)
+	if err != nil {
+		return ProjectRunResponse{}, err
+	}
+
+	log.WithField("ProjectRunResponse", newProject).Debugln()
+	return newProject, nil
+}

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -1,0 +1,95 @@
+package wharfapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type Provider struct {
+	ProviderID uint   `json:"providerId"`
+	Name       string `json:"name"`
+	URL        string `json:"url"`
+	UploadURL  string `json:"uploadUrl"`
+	TokenID    uint   `json:"tokenId"`
+}
+
+func (c Client) GetProviderById(providerID uint) (Provider, error) {
+	newProvider := Provider{}
+
+	url := fmt.Sprintf("%s/api/provider/%v", c.ApiUrl, providerID)
+	ioBody, err := doRequest("GET | PROVIDER |", http.MethodGet, url, []byte{}, c.AuthHeader)
+	if err != nil {
+		return newProvider, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newProvider)
+	if err != nil {
+		return newProvider, err
+	}
+	return newProvider, nil
+}
+
+func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr string, tokenID uint) (Provider, error) {
+	newProvider := Provider{}
+
+	path := "/api/providers/search"
+	data := url.Values{}
+	data.Set("Name", providerName)
+	data.Add("URL", urlStr)
+	data.Add("UploadURL", uploadURLStr)
+
+	if tokenID > 0 {
+		data.Add("TokenID", fmt.Sprint(tokenID))
+	}
+
+	u, _ := url.ParseRequestURI(c.ApiUrl)
+	u.Path = path
+	u.RawQuery = data.Encode()
+	url := fmt.Sprintf("%v", u)
+
+	ioBody, err := doRequest("GET | PROVIDER |", http.MethodPost, url, []byte{}, c.AuthHeader)
+	if err != nil {
+		return newProvider, err
+	}
+
+	defer (*ioBody).Close()
+
+	var providers []Provider
+	err = json.NewDecoder(*ioBody).Decode(&providers)
+	if err != nil {
+		return newProvider, err
+	}
+
+	if len(providers) == 0 {
+		return newProvider, nil
+	}
+
+	return providers[0], nil
+}
+
+func (c Client) PostProvider(provider Provider) (Provider, error) {
+	newProvider := Provider{}
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return newProvider, err
+	}
+
+	url := fmt.Sprintf("%s/api/provider", c.ApiUrl)
+	ioBody, err := doRequest("POST | PROVIDER |", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return newProvider, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newProvider)
+	if err != nil {
+		return newProvider, err
+	}
+
+	return newProvider, nil
+}

--- a/pkg/wharfapi/requestHandler.go
+++ b/pkg/wharfapi/requestHandler.go
@@ -1,0 +1,109 @@
+package wharfapi
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var redacted = "*REDACTED*"
+var tokenPatternJSON = regexp.MustCompile(`("token"\s*:\s*"([a-zA-Z\d\s]+)")\s*`)
+var tokenReplacementJSON = fmt.Sprintf(`"token":"%s"`, redacted)
+
+func redactTokenInJSON(src string) string {
+	if !tokenPatternJSON.MatchString(src) {
+		return src
+	}
+
+	return tokenPatternJSON.ReplaceAllString(src, tokenReplacementJSON)
+}
+
+func redactTokenInURL(urlStr string) string {
+	if urlStr == "" {
+		return ""
+	}
+
+	uri, err := url.Parse(urlStr)
+	if err != nil {
+		log.WithError(err).Warningln("Unable to redact token from URL: parse URL")
+		return ""
+	}
+
+	params, err := url.ParseQuery(uri.RawQuery)
+	if err != nil {
+		log.WithError(err).Warningln("Unable to redact token from URL: parse query")
+		return ""
+	}
+
+	token := params.Get("Token")
+	if token != "" {
+		params.Set("Token", redacted)
+	} else {
+		token = params.Get("token")
+		if token != "" {
+			params.Set("token", redacted)
+		}
+	}
+
+	uri.RawQuery = params.Encode()
+	newURLStr := uri.String()
+
+	sanitized, err := url.PathUnescape(newURLStr)
+	if err != nil {
+		log.WithError(err).WithField("new URL string", newURLStr).Warningln("Unable to redact token from URL: unescape path")
+		return newURLStr
+	}
+
+	return sanitized
+}
+
+func doRequest(from string, method string, URLStr string, body []byte, authHeader string) (*io.ReadCloser, error) {
+	log.WithFields(log.Fields{
+		"method": method,
+		"body":   redactTokenInJSON(string(body)),
+		"url":    redactTokenInURL(URLStr),
+	}).Debugln(from)
+
+	req, err := http.NewRequest(method, URLStr, bytes.NewReader(body))
+	if err != nil {
+		log.WithError(err).Errorln("Unable to prepare http request")
+		return nil, err
+	}
+
+	if authHeader != "" {
+		req.Header.Add("Authorization", authHeader)
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(req)
+	if err != nil {
+		log.WithError(err).Errorln("Unable to send http request")
+		return nil, err
+	}
+
+	if response.StatusCode == http.StatusUnauthorized {
+		response.Body.Close()
+		log.WithField("response", response).Errorln("Unauthorized")
+		realm := response.Header.Get("WWW-Authenticate")
+		return nil, &AuthError{realm}
+	}
+
+	if response.StatusCode < 200 && response.StatusCode >= 300 {
+		resp, err2 := ioutil.ReadAll(response.Body)
+		response.Body.Close()
+		if err2 == nil {
+			log.WithFields(log.Fields{
+				"status":        response.Status,
+				"response body": string(resp)}).Debug("Got invalid status code")
+		}
+		return nil, fmt.Errorf("unexpected status code returned %v", response.StatusCode)
+	}
+
+	return &response.Body, nil
+}

--- a/pkg/wharfapi/requestHandler_test.go
+++ b/pkg/wharfapi/requestHandler_test.go
@@ -1,0 +1,108 @@
+package wharfapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveTokenFromJSON(t *testing.T) {
+	type testCase struct {
+		name string
+		body string
+		want string
+	}
+
+	tests := []testCase{
+		{
+			name: "Not matched",
+			body: `{"tokenId":0,"userName":"","providerId":0}`,
+			want: `{"tokenId":0,"userName":"","providerId":0}`,
+		},
+		{
+			name: "Remove token from not formed JSON",
+			body: `{"tokenId":0,"token":"some token","userName":"","providerId":0}`,
+			want: `{"tokenId":0,"token":"*REDACTED*","userName":"","providerId":0}`,
+		},
+		{
+			name: "Remove token from not formed JSON with white spaces",
+			body: `{"tokenId" : 0,"token" : "some token","userName" : "","providerId" : 0}`,
+			want: `{"tokenId" : 0,"token":"*REDACTED*","userName" : "","providerId" : 0}`,
+		},
+		{
+			name: "Remove token from formed JSON",
+			body: `{
+    "tokenId": 0,
+    "token": "some token",
+    "userName": "",
+    "providerId": 0
+}
+`,
+			want: `{
+    "tokenId": 0,
+    "token":"*REDACTED*",
+    "userName": "",
+    "providerId": 0
+}
+`,
+		},
+		{
+			name: "Remove token from invalid formed JSON",
+			body: `{
+    "tokenId": 0,
+    "token":
+"some token",
+    "userName": "",
+    "providerId": 0
+}
+`,
+			want: `{
+    "tokenId": 0,
+    "token":"*REDACTED*",
+    "userName": "",
+    "providerId": 0
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactTokenInJSON(tc.body)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSanitizeURL(t *testing.T) {
+	type testCase struct {
+		name string
+		url  string
+		want string
+	}
+
+	tests := []testCase{
+		{
+			name: "Remove Token from URL",
+			url:  "https:\\\\urlhere?Token=some123token&param=value&test=sth",
+			want: "https:\\\\urlhere?Token=*REDACTED*&param=value&test=sth",
+		},
+		{
+			name: "Remove token from URL",
+			url:  "https:\\\\urlhere?test=sth&token=some123token",
+			want: "https:\\\\urlhere?test=sth&token=*REDACTED*",
+		},
+		{
+			name: "URL without token",
+			url:  "https:\\\\urlhere?test=sth",
+			want: "https:\\\\urlhere?test=sth",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactTokenInURL(tc.url)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -1,0 +1,91 @@
+package wharfapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+type Token struct {
+	TokenID    uint   `json:"tokenId"`
+	Token      string `json:"token"`
+	UserName   string `json:"userName"`
+	ProviderID uint   `json:"providerId"`
+}
+
+func (c Client) GetTokenById(tokenID uint) (Token, error) {
+	newToken := Token{}
+
+	url := fmt.Sprintf("%s/api/token/%v", c.ApiUrl, tokenID)
+	ioBody, err := doRequest("GET | TOKEN |", http.MethodGet, url, []byte{}, c.AuthHeader)
+	if err != nil {
+		return newToken, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newToken)
+	if err != nil {
+		return newToken, err
+	}
+	return newToken, nil
+}
+
+func (c Client) GetToken(token string, userName string) (Token, error) {
+	newToken := Token{}
+
+	path := "/api/tokens/search"
+
+	data := url.Values{}
+	data.Set("Token", token)
+	if userName != "" {
+		data.Add("UserName", userName)
+	}
+
+	u, _ := url.ParseRequestURI(c.ApiUrl)
+	u.Path = path
+	u.RawQuery = data.Encode()
+
+	ioBody, err := doRequest("GET | TOKEN |", http.MethodPost, fmt.Sprintf("%v", u), []byte{}, c.AuthHeader)
+	if err != nil {
+		return newToken, err
+	}
+
+	defer (*ioBody).Close()
+
+	var tokens []Token
+	err = json.NewDecoder(*ioBody).Decode(&tokens)
+	if err != nil {
+		return newToken, err
+	}
+
+	if len(tokens) == 0 {
+		return newToken, nil
+	}
+
+	return tokens[0], nil
+}
+
+func (c Client) PostToken(token Token) (Token, error) {
+	newToken := Token{}
+	body, err := json.Marshal(token)
+	if err != nil {
+		return newToken, err
+	}
+
+	url := fmt.Sprintf("%s/api/token", c.ApiUrl)
+	ioBody, err := doRequest("POST | TOKEN", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return newToken, err
+	}
+
+	defer (*ioBody).Close()
+
+	err = json.NewDecoder(*ioBody).Decode(&newToken)
+	if err != nil {
+		return newToken, err
+	}
+
+	return newToken, nil
+}


### PR DESCRIPTION
> For Iver employees: WO0000000683644

Copied over our closed-sourced repo. Some key points:

- No Git history. (we're not 100% sure we never comitted secrets in the past)

- Package name changed from `wharf` to `wharfapi`. This is to distinguish it from other future Wharf Go libraries

- I added the LICENSE file already when I created the repo through GitHubs web UI: https://github.com/iver-wharf/wharf-api-client-go/blob/master/LICENSE

- Will add tag v1.2.0 once merged

This is exiting :)
