### PR TITLE
Remove providerId from Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   | `Project.AvatarUrl`          | `Project.AvatarURL`          |
   | `ProjectRunResponse.BuildId` | `ProjectRunResponse.BuildID` |
 
+- Remove ProviderID from Token to match the corresponding change in the DB datastructure. (#6)
+
 ## v1.2.0 (2021-02-25)
 
 - Added CHANGELOG.md to repository. (!10)

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -11,7 +11,6 @@ type Token struct {
 	TokenID    uint   `json:"tokenId"`
 	Token      string `json:"token"`
 	UserName   string `json:"userName"`
-	ProviderID uint   `json:"providerId"`
 }
 
 func (c Client) GetTokenByID(tokenID uint) (Token, error) {


### PR DESCRIPTION
The database model appears to not contain any key for `providerId`. This PR removes that key from the object that models that table.