### PR TITLE
Implement PUT for /api/token and /api/provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.3.0 (WIP)
 
+- Removed field ProviderID from Token
+
 - Added problem response handling so better and more informative errors are
   returned as `wharfapi.ProblemError` instead. (#4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.3.0 (WIP)
 
-- Removed field ProviderID from Token
+- Fixed implementation of the refactor for ApiUrl to APIURL. (#8)
+
+- Added endpoint `PUT /api/provider`. (#8)
+
+- Added endpoint `PUT /api/token`. (#8)
 
 - Added problem response handling so better and more informative errors are
   returned as `wharfapi.ProblemError` instead. (#4)

--- a/pkg/wharfapi/branch.go
+++ b/pkg/wharfapi/branch.go
@@ -22,7 +22,7 @@ func (c Client) PutBranch(branch Branch) (Branch, error) {
 		return newBranch, err
 	}
 
-	url := fmt.Sprintf("%s/api/branch", c.ApiUrl)
+	url := fmt.Sprintf("%s/api/branch", c.APIURL)
 	ioBody, err := doRequest("POST | BRANCH |", http.MethodPost, url, body, c.AuthHeader)
 	if err != nil {
 		return newBranch, err
@@ -45,7 +45,7 @@ func (c Client) PutBranches(branches []Branch) ([]Branch, error) {
 		return newBranches, err
 	}
 
-	url := fmt.Sprintf("%s/api/branches", c.ApiUrl)
+	url := fmt.Sprintf("%s/api/branches", c.APIURL)
 	ioBody, err := doRequest("PUT | BRANCHES |", http.MethodPut, url, body, c.AuthHeader)
 	if err != nil {
 		return newBranches, err

--- a/pkg/wharfapi/buildlog.go
+++ b/pkg/wharfapi/buildlog.go
@@ -19,7 +19,7 @@ func (c Client) PostLog(buildID uint, buildLog BuildLog) error {
 		return err
 	}
 
-	url := fmt.Sprintf("%s/api/build/%d/log", c.ApiUrl, buildID)
+	url := fmt.Sprintf("%s/api/build/%d/log", c.APIURL, buildID)
 	_, err = doRequest("POST | LOG", http.MethodPost, url, body, c.AuthHeader)
 	if err != nil {
 		return err
@@ -29,7 +29,7 @@ func (c Client) PostLog(buildID uint, buildLog BuildLog) error {
 }
 
 func (c Client) PutStatus(buildID uint, statusID BuildStatus) (Build, error) {
-	uri := fmt.Sprintf("%s/api/build/%d?status=%s", c.ApiUrl, buildID, url.QueryEscape(statusID.String()))
+	uri := fmt.Sprintf("%s/api/build/%d?status=%s", c.APIURL, buildID, url.QueryEscape(statusID.String()))
 
 	ioBody, err := doRequest("PUT | STATUS", http.MethodPut, uri, nil, c.AuthHeader)
 	if err != nil {

--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -32,7 +32,7 @@ type ProjectRunResponse struct {
 }
 
 func (c Client) GetProjectByID(projectID uint) (Project, error) {
-	url := fmt.Sprintf("%s/api/project/%v", c.ApiUrl, projectID)
+	url := fmt.Sprintf("%s/api/project/%v", c.APIURL, projectID)
 	ioBody, err := doRequest("GET | PROJECT |", http.MethodGet, url, []byte{}, c.AuthHeader)
 	if err != nil {
 		return Project{}, err
@@ -56,7 +56,7 @@ func (c Client) PutProject(project Project) (Project, error) {
 
 	log.WithField("project", string(body)).Traceln()
 
-	url := fmt.Sprintf("%s/api/project", c.ApiUrl)
+	url := fmt.Sprintf("%s/api/project", c.APIURL)
 	ioBody, err := doRequest("PUT | PROJECT |", http.MethodPut, url, body, c.AuthHeader)
 	if err != nil {
 		return Project{}, err
@@ -81,7 +81,7 @@ func (c Client) PostProjectRun(projectRun ProjectRun) (ProjectRunResponse, error
 
 	url := fmt.Sprintf(
 		"%s/api/project/%d/%s/run?branch=%s&environment=%s",
-		c.ApiUrl,
+		c.APIURL,
 		projectRun.ProjectID,
 		projectRun.Stage,
 		projectRun.Branch,

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -18,8 +18,8 @@ type Provider struct {
 func (c Client) GetProviderByID(providerID uint) (Provider, error) {
 	newProvider := Provider{}
 
-	url := fmt.Sprintf("%s/api/provider/%v", c.APIURL, providerID)
-	ioBody, err := doRequest("GET | PROVIDER |", http.MethodGet, url, []byte{}, c.AuthHeader)
+	apiURL := fmt.Sprintf("%s/api/provider/%v", c.APIURL, providerID)
+	ioBody, err := doRequest("GET | PROVIDER |", http.MethodGet, apiURL, []byte{}, c.AuthHeader)
 	if err != nil {
 		return newProvider, err
 	}
@@ -49,9 +49,9 @@ func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr str
 	u, _ := url.ParseRequestURI(c.APIURL)
 	u.Path = path
 	u.RawQuery = data.Encode()
-	url := fmt.Sprintf("%v", u)
+	apiURL := fmt.Sprintf("%v", u)
 
-	ioBody, err := doRequest("GET | PROVIDER |", http.MethodPost, url, []byte{}, c.AuthHeader)
+	ioBody, err := doRequest("GET | PROVIDER |", http.MethodPost, apiURL, []byte{}, c.AuthHeader)
 	if err != nil {
 		return newProvider, err
 	}
@@ -78,8 +78,8 @@ func (c Client) PostProvider(provider Provider) (Provider, error) {
 		return newProvider, err
 	}
 
-	url := fmt.Sprintf("%s/api/provider", c.APIURL)
-	ioBody, err := doRequest("POST | PROVIDER |", http.MethodPost, url, body, c.AuthHeader)
+	apiURL := fmt.Sprintf("%s/api/provider", c.APIURL)
+	ioBody, err := doRequest("POST | PROVIDER |", http.MethodPost, apiURL, body, c.AuthHeader)
 	if err != nil {
 		return newProvider, err
 	}

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -18,7 +18,7 @@ type Provider struct {
 func (c Client) GetProviderByID(providerID uint) (Provider, error) {
 	newProvider := Provider{}
 
-	url := fmt.Sprintf("%s/api/provider/%v", c.ApiUrl, providerID)
+	url := fmt.Sprintf("%s/api/provider/%v", c.APIURL, providerID)
 	ioBody, err := doRequest("GET | PROVIDER |", http.MethodGet, url, []byte{}, c.AuthHeader)
 	if err != nil {
 		return newProvider, err
@@ -46,7 +46,7 @@ func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr str
 		data.Add("TokenID", fmt.Sprint(tokenID))
 	}
 
-	u, _ := url.ParseRequestURI(c.ApiUrl)
+	u, _ := url.ParseRequestURI(c.APIURL)
 	u.Path = path
 	u.RawQuery = data.Encode()
 	url := fmt.Sprintf("%v", u)
@@ -78,7 +78,7 @@ func (c Client) PostProvider(provider Provider) (Provider, error) {
 		return newProvider, err
 	}
 
-	url := fmt.Sprintf("%s/api/provider", c.ApiUrl)
+	url := fmt.Sprintf("%s/api/provider", c.APIURL)
 	ioBody, err := doRequest("POST | PROVIDER |", http.MethodPost, url, body, c.AuthHeader)
 	if err != nil {
 		return newProvider, err

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -71,6 +71,8 @@ func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr str
 	return providers[0], nil
 }
 
+// PutProvider godoc
+// Creates a new provider if a match is not found.
 func (c Client) PutProvider(provider Provider) (Provider, error) {
 	body, err := json.Marshal(provider)
 	if err != nil {

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -88,7 +88,7 @@ func (c Client) PutProvider(provider Provider) (Provider, error) {
 
 	defer (*ioBody).Close()
 
-	newProvider := Provider{}
+	var newProvider Provider
 	err = json.NewDecoder(*ioBody).Decode(&newProvider)
 	if err != nil {
 		return Provider{}, err

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -3,7 +3,6 @@ package wharfapi
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 )
@@ -77,8 +76,6 @@ func (c Client) PutProvider(provider Provider) (Provider, error) {
 	if err != nil {
 		return Provider{}, err
 	}
-
-	log.WithField("provider", string(body)).Traceln()
 
 	apiURL := fmt.Sprintf("%s/api/provider", c.APIURL)
 	ioBody, err := doRequest("PUT | PROVIDER |", http.MethodPut, apiURL, body, c.AuthHeader)

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -3,6 +3,7 @@ package wharfapi
 import (
 	"encoding/json"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 )
@@ -69,6 +70,31 @@ func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr str
 	}
 
 	return providers[0], nil
+}
+
+func (c Client) PutProvider(provider Provider) (Provider, error) {
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	log.WithField("provider", string(body)).Traceln()
+
+	apiURL := fmt.Sprintf("%s/api/provider", c.APIURL)
+	ioBody, err := doRequest("PUT | PROVIDER |", http.MethodPut, apiURL, body, c.AuthHeader)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	defer (*ioBody).Close()
+
+	newProvider := Provider{}
+	err = json.NewDecoder(*ioBody).Decode(&newProvider)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	return newProvider, nil
 }
 
 func (c Client) PostProvider(provider Provider) (Provider, error) {

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -89,8 +89,7 @@ func (c Client) PutProvider(provider Provider) (Provider, error) {
 	defer (*ioBody).Close()
 
 	var newProvider Provider
-	err = json.NewDecoder(*ioBody).Decode(&newProvider)
-	if err != nil {
+	if err := json.NewDecoder(*ioBody).Decode(&newProvider); err != nil {
 		return Provider{}, err
 	}
 

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -84,8 +84,7 @@ func (c Client) PutToken(token Token) (Token, error) {
 	defer (*ioBody).Close()
 
 	var newToken Token
-	err = json.NewDecoder(*ioBody).Decode(&newToken)
-	if err != nil {
+	if err := json.NewDecoder(*ioBody).Decode(&newToken); err != nil {
 		return Token{}, err
 	}
 

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -16,8 +16,8 @@ type Token struct {
 func (c Client) GetTokenByID(tokenID uint) (Token, error) {
 	newToken := Token{}
 
-	url := fmt.Sprintf("%s/api/token/%v", c.ApiUrl, tokenID)
-	ioBody, err := doRequest("GET | TOKEN |", http.MethodGet, url, []byte{}, c.AuthHeader)
+	apiURL := fmt.Sprintf("%s/api/token/%v", c.APIURL, tokenID)
+	ioBody, err := doRequest("GET | TOKEN |", http.MethodGet, apiURL, []byte{}, c.AuthHeader)
 	if err != nil {
 		return newToken, err
 	}
@@ -42,7 +42,7 @@ func (c Client) GetToken(token string, userName string) (Token, error) {
 		data.Add("UserName", userName)
 	}
 
-	u, _ := url.ParseRequestURI(c.ApiUrl)
+	u, _ := url.ParseRequestURI(c.APIURL)
 	u.Path = path
 	u.RawQuery = data.Encode()
 
@@ -73,8 +73,8 @@ func (c Client) PostToken(token Token) (Token, error) {
 		return newToken, err
 	}
 
-	url := fmt.Sprintf("%s/api/token", c.ApiUrl)
-	ioBody, err := doRequest("POST | TOKEN", http.MethodPost, url, body, c.AuthHeader)
+	apiURL := fmt.Sprintf("%s/api/token", c.APIURL)
+	ioBody, err := doRequest("POST | TOKEN", http.MethodPost, apiURL, body, c.AuthHeader)
 	if err != nil {
 		return newToken, err
 	}

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -66,6 +66,8 @@ func (c Client) GetToken(token string, userName string) (Token, error) {
 	return tokens[0], nil
 }
 
+// PutToken godoc
+// Creates a new token if a match is not found.
 func (c Client) PutToken(token Token) (Token, error) {
 	body, err := json.Marshal(token)
 	if err != nil {

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -67,7 +67,6 @@ func (c Client) GetToken(token string, userName string) (Token, error) {
 	return tokens[0], nil
 }
 
-
 func (c Client) PutToken(token Token) (Token, error) {
 	body, err := json.Marshal(token)
 	if err != nil {
@@ -92,7 +91,6 @@ func (c Client) PutToken(token Token) (Token, error) {
 
 	return newToken, nil
 }
-
 
 func (c Client) PostToken(token Token) (Token, error) {
 	newToken := Token{}

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -3,7 +3,6 @@ package wharfapi
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 )
@@ -72,8 +71,6 @@ func (c Client) PutToken(token Token) (Token, error) {
 	if err != nil {
 		return Token{}, err
 	}
-
-	log.WithField("project", string(body)).Traceln()
 
 	apiURL := fmt.Sprintf("%s/api/token", c.APIURL)
 	ioBody, err := doRequest("PUT | TOKEN |", http.MethodPut, apiURL, body, c.AuthHeader)

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -3,6 +3,7 @@ package wharfapi
 import (
 	"encoding/json"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 )
@@ -65,6 +66,33 @@ func (c Client) GetToken(token string, userName string) (Token, error) {
 
 	return tokens[0], nil
 }
+
+
+func (c Client) PutToken(token Token) (Token, error) {
+	body, err := json.Marshal(token)
+	if err != nil {
+		return Token{}, err
+	}
+
+	log.WithField("project", string(body)).Traceln()
+
+	apiURL := fmt.Sprintf("%s/api/token", c.APIURL)
+	ioBody, err := doRequest("PUT | TOKEN |", http.MethodPut, apiURL, body, c.AuthHeader)
+	if err != nil {
+		return Token{}, err
+	}
+
+	defer (*ioBody).Close()
+
+	newToken := Token{}
+	err = json.NewDecoder(*ioBody).Decode(&newToken)
+	if err != nil {
+		return Token{}, err
+	}
+
+	return newToken, nil
+}
+
 
 func (c Client) PostToken(token Token) (Token, error) {
 	newToken := Token{}

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -83,7 +83,7 @@ func (c Client) PutToken(token Token) (Token, error) {
 
 	defer (*ioBody).Close()
 
-	newToken := Token{}
+	var newToken Token
 	err = json.NewDecoder(*ioBody).Decode(&newToken)
 	if err != nil {
 		return Token{}, err


### PR DESCRIPTION
This mirrors the implementation of the `PUT /api/project` for the new endpoints `PUT /api/token` and `PUT /api/provider`

There is also a missing reference to the variable ApiUrl on Client. This is changed to match the source struct as `APIURL`. 

This goes together with a few other PRs:
- (This) The implementable interface https://github.com/iver-wharf/wharf-api-client-go/pull/8
- The PUT /api/token https://github.com/iver-wharf/wharf-api/pull/26
- The PUT /api/provider https://github.com/iver-wharf/wharf-api/pull/28
- The gtihub-provider changes that require the rest https://github.com/iver-wharf/wharf-provider-github/pull/10