### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.0 (2021-06-14)
+## v1.3.0 (2021-06-10)
 
 - Fixed implementation of the refactor for ApiUrl to APIURL. (#8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v1.3.0 (WIP)
+## v1.3.0 (2021-06-14)
 
 - Fixed implementation of the refactor for ApiUrl to APIURL. (#8)
 


### PR DESCRIPTION
This is needed to merge https://github.com/iver-wharf/wharf-provider-github/pull/10

## New in v1.3.0

- Fixed implementation of the refactor for ApiUrl to APIURL. (#8)

- Added endpoint `PUT /api/provider`. (#8)
- Added endpoint `PUT /api/token`. (#8)
- Added problem response handling so better and more informative errors are
  returned as `wharfapi.ProblemError` instead. (#4)
- Fixed "non-2xx status code" checks. (#4)
- Fixed invalid initialisms in method and field names. Affected names: (#5)
  | Before                       | After                        |
  | ------                       | -----                        |
  | `Client.ApiUrl`              | `Client.APIURL`              |
  | `Client.GetProjectById`      | `Client.GetProjectByID`      |
  | `Client.GetProviderById`     | `Client.GetProviderByID`     |
  | `Client.GetTokenById`        | `Client.GetTokenByID`        |
  | `Project.AvatarUrl`          | `Project.AvatarURL`          |
  | `ProjectRunResponse.BuildId` | `ProjectRunResponse.BuildID` |
- Remove ProviderID from Token to match the corresponding change in the DB datastructure. (#6)