### PR TITLE
Added 1:1 of search endpoints

### DIFF
--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -53,6 +53,32 @@ func (c Client) GetProjectByID(projectID uint) (Project, error) {
 	return newProject, nil
 }
 
+// SearchProject tries to match the given project on all non-zero fields by
+// invoking the HTTP request:
+// 	POST /api/projects/search
+func (c Client) SearchProject(project Project) ([]Project, error) {
+	body, err := json.Marshal(project)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/api/projects/search", c.APIURL)
+	ioBody, err := doRequest("SEARCH | PROJECT |", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	defer (*ioBody).Close()
+
+	var foundProjects []Project
+	err = json.NewDecoder(*ioBody).Decode(&foundProjects)
+	if err != nil {
+		return nil, err
+	}
+
+	return foundProjects, nil
+}
+
 // PutProject tries to match an existing project by ID or name+group and updates
 // it, or adds a new a project if none matched, by invoking the HTTP request:
 // 	PUT /api/project

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -38,7 +38,7 @@ func (c Client) GetProviderByID(providerID uint) (Provider, error) {
 
 // GetProvider tries to find a provider based on its name, URL, etc. by invoking
 // the HTTP request:
-// 	GET /api/providers/search
+// 	POST /api/providers/search
 func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr string, tokenID uint) (Provider, error) {
 	newProvider := Provider{}
 
@@ -75,6 +75,34 @@ func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr str
 	}
 
 	return providers[0], nil
+}
+
+// SearchProvider tries to match the given provider on the provider name, URL,
+// upload URL, and token ID, by invoking the HTTP request:
+// 	POST /api/providers/search
+//
+// The token ID is not queried if the argument's tokenID field is set to zero.
+func (c Client) SearchProvider(provider Provider) ([]Provider, error) {
+	body, err := json.Marshal(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/api/projects/search", c.APIURL)
+	ioBody, err := doRequest("SEARCH | PROVIDER |", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	defer (*ioBody).Close()
+
+	var foundProviders []Provider
+	err = json.NewDecoder(*ioBody).Decode(&foundProviders)
+	if err != nil {
+		return nil, err
+	}
+
+	return foundProviders, nil
 }
 
 // PutProvider tries to match an existing provider by ID or combination of name,

--- a/pkg/wharfapi/token.go
+++ b/pkg/wharfapi/token.go
@@ -37,7 +37,7 @@ func (c Client) GetTokenByID(tokenID uint) (Token, error) {
 
 // GetToken tries to search for a token using the username+token pair by
 // invoking the HTTP request:
-// 	GET /api/token/search
+// 	POST /api/token/search
 func (c Client) GetToken(token string, userName string) (Token, error) {
 	newToken := Token{}
 
@@ -71,6 +71,32 @@ func (c Client) GetToken(token string, userName string) (Token, error) {
 	}
 
 	return tokens[0], nil
+}
+
+// SearchToken tries to match the given token on the token field and username
+// field, by invoking the HTTP request:
+// 	POST /api/tokens/search
+func (c Client) SearchToken(token Token) ([]Token, error) {
+	body, err := json.Marshal(token)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s/api/projects/search", c.APIURL)
+	ioBody, err := doRequest("SEARCH | TOKEN |", http.MethodPost, url, body, c.AuthHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	defer (*ioBody).Close()
+
+	var foundTokens []Token
+	err = json.NewDecoder(*ioBody).Decode(&foundTokens)
+	if err != nil {
+		return nil, err
+	}
+
+	return foundTokens, nil
 }
 
 // PutToken tries to match an existing token by ID or username+token and updates


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added new methods:

  - `Client.SearchProject(Project) []Project`: `POST /api/projects/search`
  - `Client.SearchProvider(Provider) []Provider`: `POST /api/providers/search`
  - `Client.SearchToken(Token) []Token`: `POST /api/tokens/search`

## Motivation

These endpoints were missing from the wharf-api-client-go. They sort of existed in the `GetProvider` and `GetToken` that called the search endpoint, but they did not return the full search result list.

There is a `POST /api/builds/search` as well but that one is marked as "NOT IMPLEMENTED" so I'm waiting with that one.
