### PR TITLE
Removed UploadURL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.0.0 (WIP)
+
+- Removed the `wharfapi.Provider.UploadURL` field, which will be removed from
+  the `Provider` struct in `github.com/iver-wharf/wharf-api` in v5.0.0. (#21)
+
 ## v1.4.0 (2021-09-07)
 
 - Added methods for search endpoints: (#18)

--- a/pkg/wharfapi/provider.go
+++ b/pkg/wharfapi/provider.go
@@ -12,7 +12,6 @@ type Provider struct {
 	ProviderID uint   `json:"providerId"`
 	Name       string `json:"name"`
 	URL        string `json:"url"`
-	UploadURL  string `json:"uploadUrl"`
 	TokenID    uint   `json:"tokenId"`
 }
 
@@ -39,14 +38,13 @@ func (c Client) GetProviderByID(providerID uint) (Provider, error) {
 // GetProvider tries to find a provider based on its name, URL, etc. by invoking
 // the HTTP request:
 // 	POST /api/providers/search
-func (c Client) GetProvider(providerName string, urlStr string, uploadURLStr string, tokenID uint) (Provider, error) {
+func (c Client) GetProvider(providerName, urlStr string, tokenID uint) (Provider, error) {
 	newProvider := Provider{}
 
 	path := "/api/providers/search"
 	data := url.Values{}
 	data.Set("Name", providerName)
 	data.Add("URL", urlStr)
-	data.Add("UploadURL", uploadURLStr)
 
 	if tokenID > 0 {
 		data.Add("TokenID", fmt.Sprint(tokenID))


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Removed the `wharfapi.Provider.UploadURL` field.
Removed any references to `UploadURL`.

## Motivation

These fields did not provide any functionality and were thus effectively bloat.

--
Closes #20.
