### PR TITLE
Added RemoteProjectID field to Project struct

### DIFF
--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -18,6 +18,7 @@ type Project struct {
 	AvatarURL       string `json:"avatarUrl"`
 	ProviderID      uint   `json:"providerId"`
 	GitURL          string `json:"gitUrl"`
+	RemoteProjectID string `json:"remoteProjectId"`
 }
 
 // ProjectRun is a range of options you start a build with. The ProjectID and


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

- [ ] Wait for iver-wharf/wharf-api#112 to be merged and released.

## Summary

Added `Project.RemoteProjectID` field.

## Motivation

Need to add this field to stay up-to-date with wharf-api.

--

Closes #25.
