### PR TITLE
Appended /v2 to Go module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v2.0.0 (WIP)
 
+- BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`
+  to `github.com/iver-wharf/wharf-api-client-go/v2`. (#30)
+
 - Removed the `wharfapi.Provider.UploadURL` field, which will be removed from
   the `Provider` struct in `github.com/iver-wharf/wharf-api` in v5.0.0. (#21)
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ into the database when importing from GitLab, GitHub, or Azure DevOps.
 
 ## Usage
 
+```console
+$ go get github.com/iver-wharf/wharf-api-client-go/v2
+```
+
 ```go
 package main
 
 import (
 	"fmt"
-	"github.com/iver-wharf/wharf-api-client-go/pkg/wharfapi"
+	"github.com/iver-wharf/wharf-api-client-go/v2/pkg/wharfapi"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ into the database when importing from GitLab, GitHub, or Azure DevOps.
 ## Usage
 
 ```console
-$ go get github.com/iver-wharf/wharf-api-client-go/v2
+$ go get github.com/iver-wharf/wharf-api-client-go/v2/pkg/wharfapi
 ```
 
 ```go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/iver-wharf/wharf-api-client-go
+module github.com/iver-wharf/wharf-api-client-go/v2
 
 go 1.13
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed module path from `github.com/iver-wharf/wharf-api-client-go` to `github.com/iver-wharf/wharf-api-client-go/v5`

## Motivation

Based on published RFC: https://iver-wharf.github.io/rfcs/published/0026-v2-go-modules-release
Meta issue: iver-wharf/iver-wharf.github.io#82