### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (WIP)
+## v2.0.0 (2022-01-24)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`
   to `github.com/iver-wharf/wharf-api-client-go/v2`. (#30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - BREAKING: Removed support for wharf-api v4.2.0 and below. (#29)
 
-- Added support for wharf-api v5. (#29)
+- Added support for `github.com/iver-wharf/wharf-api` v5.0.0. (#29)
 
 - Changed version of `github.com/iver-wharf/wharf-core` from v1.2.0 to v1.3.0.
   (#29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.0.0 (2022-01-24)
+## v2.0.0 (2022-01-25)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`
   to `github.com/iver-wharf/wharf-api-client-go/v2`. (#30)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`
  to `github.com/iver-wharf/wharf-api-client-go/v2`. (#30)

- BREAKING: Changed minimum version of Go from 1.13 to 1.16. (#29)

- BREAKING: Removed support for wharf-api v4.2.0 and below. (#29)

- Added support for wharf-api v5. (#29)

- Changed version of `github.com/iver-wharf/wharf-core` from v1.2.0 to v1.3.0.
  (#29)

- Added dependency `github.com/google/go-querystring` v1.1.0. (#29)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
