### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix
+lint-fix: lint-md-fix lint-go-fix
 
 lint-md:
 	npx remark . .github
@@ -23,4 +23,8 @@ lint-md-fix:
 	npx remark . .github -o
 
 lint-go:
+	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
+
+lint-go-fix:
+	goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,17 @@ deps:
 	npm install
 
 lint: lint-md lint-go
-lint-fix: lint-md-fix lint-go-fix
+lint-fix: lint-fix-md lint-fix-go
 
 lint-md:
 	npx remark . .github
 
-lint-md-fix:
+lint-fix-md:
 	npx remark . .github -o
 
 lint-go:
 	goimports -d $(shell git ls-files "*.go")
 	revive -formatter stylish -config revive.toml ./...
 
-lint-go-fix:
+lint-fix-go:
 	goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: tidy deps \
+	lint lint-md lint-go \
+	lint-fix lint-md-fix
+
+tidy:
+	go mod tidy
+
+deps:
+	go install github.com/mgechev/revive@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+	npm install
+
+lint: lint-md lint-go
+lint-fix: lint-md-fix
+
+lint-md:
+	npx remark . .github
+
+lint-md-fix:
+	npx remark . .github -o
+
+lint-go:
+	revive -formatter stylish -config revive.toml ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check tidy deps \
 	lint lint-md lint-go \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md lint-fix-go
 
 check:
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-.PHONY: tidy deps \
+.PHONY: check tidy deps \
 	lint lint-md lint-go \
 	lint-fix lint-md-fix
+
+check:
+	go test ./...
 
 tidy:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -89,11 +89,20 @@ npm run lint-md-fix
 You can lint all of the above at the same time by running:
 
 ```sh
-npm run lint
+make lint
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+make lint-go # only lint Go code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-go # Go linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ npm run lint-md-fix
 
 ## Linting
 
-Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-go # only lint Go code

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ files in place.
 ```sh
 make lint-fix
 
-make lint-fix-go # only lint and fix Markdown files
+make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ files in place.
 ```sh
 make lint-fix
 
-#make lint-fix-go # Go linter does not support fixes
+make lint-fix-go # only lint and fix Markdown files
 make lint-fix-md # only lint and fix Markdown files
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,33 +57,6 @@ GET | PROJECT | 125
 Project #125: MyProject
 ```
 
-## Linting Golang
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-- Requires Revive to be installed: <https://revive.run/>
-
-```sh
-go get -u github.com/mgechev/revive
-```
-
-```sh
-npm run lint-go
-```
-
-## Linting markdown
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
-```sh
-npm install
-
-npm run lint-md
-
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
-```
-
 ## Linting
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm run lint-md-fix
 
 ## Linting
 
-You can lint all of the above at the same time by running:
+Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
 
 ```sh
 make lint

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "scripts": {
-    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
-    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark . .github",
-    "lint-md-fix": "remark . .github -o",
-    "lint-go": "revive -formatter stylish -config revive.toml ./..."
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting and other utilities like cleaning
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
