### PR TITLE
Upgraded to Go v1.17

### DIFF
--- a/.github/workflows/go-format.yml
+++ b/.github/workflows/go-format.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16'
+          go-version: '1.17'
 
       - name: Set up gotestfmt
         uses: haveyoudebuggedit/gotestfmt-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.1.0 (WIP)
+
+- Changed minimum version of Go from 1.16 to 1.17. (#36)
+
 ## v2.0.0 (2022-01-25)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`
   to `github.com/iver-wharf/wharf-api-client-go/v2`. (#30)
 
-- BREAKING: Changed minimum version of Go from 1.13 to 1.16. (#29)
-
 - BREAKING: Removed support for wharf-api v4.2.0 and below. (#29)
+
+- Changed minimum version of Go from 1.13 to 1.16. (#29)
 
 - Added support for `github.com/iver-wharf/wharf-api` v5.0.0. (#29)
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
 module github.com/iver-wharf/wharf-api-client-go/v2
 
-go 1.16
+go 1.17
 
 require (
 	github.com/google/go-querystring v1.1.0
 	github.com/iver-wharf/wharf-core v1.3.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/guregu/null.v4 v4.0.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Upgraded to Go 1.17

## Motivation

I unmarked the Go version upgrade as a BREAKING change as it's not really a breaking change. We still support the older versions.

With that, I only bumped the minor version for this.

