### PR TITLE
Changed build status to use slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed minimum version of Go from 1.16 to 1.17. (#36)
 
+- Changed `BuildSearch.Status` to a slice to support searching for builds of any
+  matching status. Support was added to wharf-api in v5.1.0 with [wharf-api#150](https://github.com/iver-wharf/wharf-api/pull/150).
+  (#37)
+
 ## v2.0.0 (2022-01-25)
 
 - BREAKING: Changed module path from `github.com/iver-wharf/wharf-api-client-go`

--- a/pkg/wharfapi/build.go
+++ b/pkg/wharfapi/build.go
@@ -23,9 +23,9 @@ type BuildSearch struct {
 	FinishedAfter   *time.Time `url:"finishedAfter,omitempty"`
 	FinishedBefore  *time.Time `url:"finishedBefore,omitempty"`
 
-	IsInvalid *bool   `url:"isInvalid,omitempty"`
-	Status    *string `url:"status,omitempty"`
-	StatusID  *int    `url:"statusId,omitempty"`
+	IsInvalid *bool    `url:"isInvalid,omitempty"`
+	Status    []string `url:"status,omitempty"`
+	StatusID  []int    `url:"statusId,omitempty"`
 
 	Environment *string `url:"environment,omitempty"`
 	GitBranch   *string `url:"gitBranch,omitempty"`


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs
- \[x] Wait for https://github.com/iver-wharf/wharf-api/pull/150 to be merged.

## Summary

- Changed `BuildSearch` to allow slice of statuses instead of only one value.

## Motivation

Support on the backend was introduced in v5.1.0: https://github.com/iver-wharf/wharf-api/pull/150
