### PR TITLE
Remaining client-side endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Added numerous dependencies:
 
   - `github.com/alta/protopatch` v0.5.0 (#35)
+  - `github.com/blang/semver/v4` v4.0.0. (#39)
   - `golang.org/x/oauth2` v0.0.0-20200107190931-bf48bf16ab8d (#35)
   - `google.golang.org/grpc` v1.44.0 (#35)
   - `google.golang.org/protobuf` v1.27.1 (#35)
@@ -39,6 +40,29 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - `Client.GetVersion() app.Version`: `GET /api/version`
   - `Client.Ping() Ping`: `GET /api/ping`
 
+- Added methods for project overrides: (#40)
+
+  - `Client.GetProjectOverrides(uint) ProjectOverrides`:
+    `GET /api/project/{projectId}/override`
+
+  - `Client.UpdateProjectOverrides(uint, ProjectOverridesUpdate) ProjectOverrides`:
+    `PUT /api/project/{projectId}/override`
+
+  - `Client.DeleteProjectOverrides(uint)`:
+    `DELETE /api/project/{projectId}/override`
+
+- Added method to delete a project (USE WITH CAUTION!): (#40)
+
+  - `Client.DeleteProject(uint)`: `DELETE /api/project/{projectId}`
+
+- Added methods for uploading artifacts and test results: (#40)
+
+  - `Client.CreateBuildArtifact(uint, string, io.Reader)`:
+    `POST /api/build/{buildId}/artifact`
+
+  - `Client.CreateBuildTestResult(uint, string, io.Reader) []ArtifactMetadata`:
+    `POST /api/build/{buildId}/artifact`
+
 - Added client and server version validation on all endpoints. This is disabled
   by default, but can be enabled with the following new flags: (#39)
 
@@ -52,7 +76,14 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed `Client` method receiver to a pointer on all methods. This will not
   break regular usage, but may break edge case usages during compilation. (#39)
 
-- Added dependency `github.com/blang/semver/v4` v4.0.0. (#39)
+- Changed all endpoints that sends JSON payload in the request to stream the
+  writing instead of buffering it. This will lower the memory footprint for
+  larger payloads. (#40)
+
+- Fixed `GetBuildArtifact` having invalid implementation where it expected an
+  artifact JSON response, while in reality that's the endpoint to download an
+  artifact. This will break compilation of existing code, but the endpoint
+  never worked before to begin with. (#40)
 
 ## v2.0.0 (2022-01-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
     `POST /api/build/{buildId}/artifact`
 
   - `Client.CreateBuildTestResult(uint, string, io.Reader) []ArtifactMetadata`:
-    `POST /api/build/{buildId}/artifact`
+    `POST /api/build/{buildId}/test-result`
 
 - Added client and server version validation on all endpoints. This is disabled
   by default, but can be enabled with the following new flags: (#39)

--- a/pkg/wharfapi/artifact.go
+++ b/pkg/wharfapi/artifact.go
@@ -47,15 +47,12 @@ func (c *Client) GetBuildArtifactList(params ArtifactSearch, buildID uint) (resp
 //  GET /api/build/{buildId}/artifact/{artifactId}
 //
 // Added in wharf-api v0.7.1.
-func (c *Client) GetBuildArtifact(buildID, artifactID uint) (response.Artifact, error) {
-	// TODO: Receive multipart file, not response.Artifact
+func (c *Client) GetBuildArtifact(buildID, artifactID uint) (io.ReadCloser, error) {
 	if err := c.validateEndpointVersion(0, 7, 1); err != nil {
-		return response.Artifact{}, err
+		return nil, err
 	}
-	var artifact response.Artifact
 	path := fmt.Sprintf("/api/build/%d/artifact/%d", buildID, artifactID)
-	err := c.getUnmarshal(path, nil, &artifact)
-	return artifact, err
+	return c.get(path, nil)
 }
 
 // CreateBuildArtifact uploads an artifact by invoking the HTTP request:

--- a/pkg/wharfapi/client.go
+++ b/pkg/wharfapi/client.go
@@ -150,6 +150,14 @@ func (c *Client) newRequest(method, path string, q url.Values, body io.Reader) (
 	return newRequest(method, c.AuthHeader, c.APIURL, path, q, body)
 }
 
+func (c *Client) delete(path string, q url.Values, body io.Reader) (io.ReadCloser, error) {
+	req, err := c.newRequest(http.MethodDelete, path, q, body)
+	if err != nil {
+		return nil, err
+	}
+	return doRequest(req)
+}
+
 // SetCachedVersion will override the version that the wharf-api-client-go
 // thinks the remote API has when validating the Client.ErrIfOutdatedServer.
 func (c *Client) SetCachedVersion(major, minor, patch uint64) {

--- a/pkg/wharfapi/client.go
+++ b/pkg/wharfapi/client.go
@@ -268,7 +268,7 @@ func newJSONEncodeReader(obj interface{}) io.ReadCloser {
 	r, w := io.Pipe()
 	enc := json.NewEncoder(w)
 	go func(obj interface{}, enc *json.Encoder, w *io.PipeWriter) {
-		enc.Encode(obj)
+		w.CloseWithError(enc.Encode(obj))
 	}(obj, enc, w)
 	return r
 }

--- a/pkg/wharfapi/client.go
+++ b/pkg/wharfapi/client.go
@@ -157,19 +157,6 @@ func (c *Client) delete(path string, q url.Values, body io.Reader) (io.ReadClose
 	return doRequest(req)
 }
 
-func decodeJSONAndClose(r io.ReadCloser, obj interface{}) (finalErr error) {
-	defer closeAndSetError(r, &finalErr)
-	finalErr = json.NewDecoder(r).Decode(obj)
-	return
-}
-
-func closeAndSetError(closer io.Closer, errPtr *error) {
-	closeErr := closer.Close()
-	if errPtr != nil && *errPtr == nil {
-		*errPtr = closeErr
-	}
-}
-
 // SetCachedVersion will override the version that the wharf-api-client-go
 // thinks the remote API has when validating the Client.ErrIfOutdatedServer.
 func (c *Client) SetCachedVersion(major, minor, patch uint64) {

--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -118,7 +118,7 @@ func (c *Client) GetProjectOverrides(projectID uint) (response.ProjectOverrides,
 	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
 		return response.ProjectOverrides{}, err
 	}
-	path := fmt.Sprintf("/api/project/%v/override", projectID)
+	path := fmt.Sprintf("/api/project/%d/override", projectID)
 	var overrides response.ProjectOverrides
 	err := c.getUnmarshal(path, nil, &overrides)
 	return overrides, err

--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -89,3 +89,50 @@ func (c *Client) UpdateProject(projectID uint, project request.ProjectUpdate) (r
 	err := c.putJSONUnmarshal(path, nil, project, &updatedProject)
 	return updatedProject, err
 }
+
+// GetProjectOverrides fetches a project's overrides by project ID by invoking the
+// HTTP request:
+//  GET /api/project/{projectID}/override
+//
+// Added in wharf-api v5.0.0.
+func (c *Client) GetProjectOverrides(projectID uint) (response.ProjectOverrides, error) {
+	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
+		return response.ProjectOverrides{}, err
+	}
+	path := fmt.Sprintf("/api/project/%v/override", projectID)
+	var overrides response.ProjectOverrides
+	err := c.getUnmarshal(path, nil, &overrides)
+	return overrides, err
+}
+
+// UpdateProjectOverrides updates a project's overrides by project ID by
+// invoking the HTTP request:
+//  PUT /api/project/{projectID}/override
+//
+// Added in wharf-api v5.0.0.
+func (c *Client) UpdateProjectOverrides(projectID uint, overrides request.ProjectOverridesUpdate) (response.ProjectOverrides, error) {
+	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
+		return response.ProjectOverrides{}, err
+	}
+	var updatedOverrides response.ProjectOverrides
+	path := fmt.Sprintf("/api/project/%d/override", projectID)
+	err := c.putJSONUnmarshal(path, nil, overrides, &updatedOverrides)
+	return updatedOverrides, err
+}
+
+// DeleteProjectOverrides clears a project's overrides by project ID by
+// invoking the HTTP request:
+//  DELETE /api/project/{projectID}/override
+//
+// Added in wharf-api v5.0.0.
+func (c *Client) DeleteProjectOverrides(projectID uint) error {
+	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/api/project/%d/override", projectID)
+	resp, err := c.delete(path, nil, nil)
+	if err != nil {
+		return err
+	}
+	return resp.Close()
+}

--- a/pkg/wharfapi/project.go
+++ b/pkg/wharfapi/project.go
@@ -90,6 +90,25 @@ func (c *Client) UpdateProject(projectID uint, project request.ProjectUpdate) (r
 	return updatedProject, err
 }
 
+// DeleteProject deletes a project by ID by invoking the HTTP request:
+//  DELETE /api/project/{projectID}/override
+//
+// This will also delete all associated artifacts, builds, and logs. This is an
+// irreversable action.
+//
+// Added in wharf-api v0.2.8.
+func (c *Client) DeleteProject(projectID uint) error {
+	if err := c.validateEndpointVersion(0, 2, 8); err != nil {
+		return err
+	}
+	path := fmt.Sprintf("/api/project/%d", projectID)
+	resp, err := c.delete(path, nil, nil)
+	if err != nil {
+		return err
+	}
+	return resp.Close()
+}
+
 // GetProjectOverrides fetches a project's overrides by project ID by invoking the
 // HTTP request:
 //  GET /api/project/{projectID}/override

--- a/pkg/wharfapi/requestHandler.go
+++ b/pkg/wharfapi/requestHandler.go
@@ -1,7 +1,6 @@
 package wharfapi
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,7 +15,7 @@ var redacted = "*REDACTED*"
 var tokenPatternJSON = regexp.MustCompile(`("token"\s*:\s*"([a-zA-Z\d\s]+)")\s*`)
 var tokenReplacementJSON = fmt.Sprintf(`"token":"%s"`, redacted)
 
-func newRequest(method, authHeader, baseURL, path string, q url.Values, body []byte) (*http.Request, error) {
+func newRequest(method, authHeader, baseURL, path string, q url.Values, body io.Reader) (*http.Request, error) {
 	u, err := newURL(baseURL, path, q)
 	if err != nil {
 		return nil, err
@@ -34,9 +33,9 @@ func newURL(baseURL, path string, q url.Values) (*url.URL, error) {
 	return u, nil
 }
 
-func newRequestFromURL(method, authHeader string, u *url.URL, body []byte) (*http.Request, error) {
+func newRequestFromURL(method, authHeader string, u *url.URL, body io.Reader) (*http.Request, error) {
 	urlStr := u.String()
-	req, err := http.NewRequest(method, urlStr, bytes.NewReader(body))
+	req, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
 		log.Error().WithError(err).Message("Failed preparing HTTP request.")
 		return nil, err

--- a/pkg/wharfapi/test_result.go
+++ b/pkg/wharfapi/test_result.go
@@ -93,7 +93,7 @@ func (c *Client) CreateBuildTestResult(buildID uint, fileName string, testResult
 	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
 		return nil, err
 	}
-	path := fmt.Sprintf("/api/build/%d/test-result", buildID)
+	path := fmt.Sprintf("/api/build/%d/test-result/", buildID)
 	body, err := c.uploadMultipart(http.MethodPost, path, map[string]file{
 		"files": {
 			fileName: fileName,

--- a/pkg/wharfapi/util.go
+++ b/pkg/wharfapi/util.go
@@ -1,7 +1,9 @@
 package wharfapi
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -34,5 +36,23 @@ func trimProtocol(v string) string {
 		return strings.TrimPrefix(v, "https://")
 	default:
 		return v
+	}
+}
+
+func decodeJSONAndClose(r io.ReadCloser, obj interface{}) (finalErr error) {
+	defer closeAndSetError(r, &finalErr)
+	finalErr = json.NewDecoder(r).Decode(obj)
+	return
+}
+
+// closeAndSetError may be used to set the named return variable inside a
+// deferred call if that deferred call failed.
+//
+// NOTE: The errPtr argument must be a pointer to a named result parameters,
+// otherwise it will not affect the calling function's returned value.
+func closeAndSetError(closer io.Closer, errPtr *error) {
+	closeErr := closer.Close()
+	if errPtr != nil && *errPtr == nil {
+		*errPtr = closeErr
 	}
 }


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed request to deal with readers instead of `[]byte`
- Added CreateBuildArtifact
- Added CreateBuildTestResult
- Added GetProjectOverrides
- Added UpdateProjectOverrides
- Added DeleteProjectOverrides
- Added DeleteProject
- Fixed GetBuildArtifact to download artifact

## Motivation

There's a breaking change hidden in here, and that's the change of signature in GetBuildArtifact. I decided to change the whole method signature so it breaks stuff during compilation instead of during runtime, as that method has never worked.

Did some research and turns out we don't need to do any manual multipart reading when downloading artifacts as the regular GET request will handle this for us.

POSTing with multipart was not as straight forward though, so that one is the most complex part of this PR.

Closes #31

There's one endpoint that I've not implemented, and that's the SSE-based StreamBuildLog endpoint. I suggest adding moving that to a separate issue as it is not needed right now (or probably even ever)
