### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.1.0 (WIP)
+## v2.1.0 (2021-03-08)
 
 - Added `Client.CreateBuildLogStream` that uses wharf-api's gRPC API that was
   introduced in wharf-api v5.1.0 to allow streaming log creation. (#35)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Added `Client.CreateBuildLogStream` that uses wharf-api's gRPC API that was introduced in wharf-api v5.1.0 to allow streaming log creation. (#35)

- Added numerous dependencies:

  - `github.com/alta/protopatch` v0.5.0 (#35)
  - `github.com/blang/semver/v4` v4.0.0. (#39)
  - `golang.org/x/oauth2` v0.0.0-20200107190931-bf48bf16ab8d (#35)
  - `google.golang.org/grpc` v1.44.0 (#35)
  - `google.golang.org/protobuf` v1.27.1 (#35)

- Changed minimum version of Go from 1.16 to 1.17. (#36)

- Changed `BuildSearch.Status` to a slice to support searching for builds of any matching status. Support was added to wharf-api in v5.1.0 with [wharf-api#150](https://github.com/iver-wharf/wharf-api/pull/150). (#37)

- Added `WorkerID` to `response.Build` model, as added in [wharf-api#156](https://github.com/iver-wharf/wharf-api/pull/156). (#38)

- Added methods for API health and metadata: (#39)

  - `Client.GetHealth() HealthStatus`: `GET /api/health`
  - `Client.GetVersion() app.Version`: `GET /api/version`
  - `Client.Ping() Ping`: `GET /api/ping`

- Added methods for project overrides: (#40)

  - `Client.GetProjectOverrides(uint) ProjectOverrides`: `GET /api/project/{projectId}/override`

  - `Client.UpdateProjectOverrides(uint, ProjectOverridesUpdate) ProjectOverrides`: `PUT /api/project/{projectId}/override`

  - `Client.DeleteProjectOverrides(uint)`: `DELETE /api/project/{projectId}/override`

- Added method to delete a project (USE WITH CAUTION!): (#40)

  - `Client.DeleteProject(uint)`: `DELETE /api/project/{projectId}`

- Added methods for uploading artifacts and test results: (#40)

  - `Client.CreateBuildArtifact(uint, string, io.Reader)`: `POST /api/build/{buildId}/artifact`

  - `Client.CreateBuildTestResult(uint, string, io.Reader) []ArtifactMetadata`: `POST /api/build/{buildId}/test-result`

- Added client and server version validation on all endpoints. This is disabled by default, but can be enabled with the following new flags: (#39)

  ```go
  client := wharfapi.Client{
      ErrIfOutdatedClient: true,
      ErrIfOutdatedServer: true,
	}
  ```

- Changed `Client` method receiver to a pointer on all methods. This will not break regular usage, but may break edge case usages during compilation. (#39)

- Changed all endpoints that sends JSON payload in the request to stream the writing instead of buffering it. This will lower the memory footprint for larger payloads. (#40)

- Fixed `GetBuildArtifact` having invalid implementation where it expected an artifact JSON response, while in reality that's the endpoint to download an artifact. This will break compilation of existing code, but the endpoint never worked before to begin with. (#40)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
