### PR TITLE
Added engine support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v2.2.0 (WIP)
+
+- Added methods for execution engine: (#45)
+
+  - `Client.GetEngineList() EngineList`: `GET /api/engine`
+
+- Added query parameter for specifying engine in new builds: (#45)
+
+  - `ProjectStartBuild.Engine`: `POST /api/project/{projectId}/build?engine=...`
+
 ## v2.1.0 (2021-03-08)
 
 - Added `Client.CreateBuildLogStream` that uses wharf-api's gRPC API that was

--- a/pkg/model/request/request.go
+++ b/pkg/model/request/request.go
@@ -2,7 +2,7 @@
 // and Swaggo documentation for the HTTP request models, with Gin- and
 // Swaggo-specific Go tags.
 //
-// Copied from https://github.com/iver-wharf/wharf-api/blob/v5.0.0/pkg/model/request/request.go
+// Copied from https://github.com/iver-wharf/wharf-api/blob/v5.1.2/pkg/model/request/request.go
 package request
 
 import (

--- a/pkg/model/response/response.go
+++ b/pkg/model/response/response.go
@@ -1,7 +1,7 @@
 // Package response contains plain old Go types returned by wharf-web in the
 // HTTP responses, with Swaggo-specific Go tags.
 //
-// Copied from https://github.com/iver-wharf/wharf-api/blob/v5.0.0/pkg/model/response/response.go
+// Copied from https://github.com/iver-wharf/wharf-api/blob/v5.1.2/pkg/model/response/response.go
 package response
 
 import (
@@ -101,11 +101,12 @@ type Build struct {
 	GitBranch             string                `json:"gitBranch"`
 	Environment           null.String           `json:"environment" swaggertype:"string" extensions:"x-nullable"`
 	Stage                 string                `json:"stage"`
-	WorkerID              string                `json:"workerId"`
+	WorkerID              string                `json:"workerId" example:"5d6bcf20-81fd-4ad8-a446-735aa8423dfe"`
 	Params                []BuildParam          `json:"params"`
 	IsInvalid             bool                  `json:"isInvalid"`
 	TestResultSummaries   []TestResultSummary   `json:"testResultSummaries"`
 	TestResultListSummary TestResultListSummary `json:"testResultListSummary"`
+	Engine                *Engine               `json:"engine" extensions:"x-nullable"`
 }
 
 // BuildParam holds the name and value of an input parameter fed into a build.
@@ -138,6 +139,23 @@ const (
 	// in some build step.
 	BuildFailed BuildStatus = "Failed"
 )
+
+// Engine is an execution engine wharf-api uses to perform its builds.
+// Engines are configured in wharf-api's configuration, and cannot be changed
+// on a running instance of wharf-api.
+type Engine struct {
+	ID   string `json:"id" example:"primary"`
+	Name string `json:"name" example:"Primary"`
+	URL  string `json:"url" example:"http://wharf-cmd-provisioner/trigger"`
+}
+
+// EngineList contains a list of execution engines that the wharf-api is
+// configured with, as well as a declaration of which one is the default engine
+// that will be used on new builds if no engine is specified.
+type EngineList struct {
+	DefaultEngine *Engine  `json:"defaultEngine" extensions:"x-nullable"`
+	List          []Engine `json:"list"`
+}
 
 // HealthStatus holds a human-readable string stating the health of the API and
 // its integrations, as well as a boolean for easy machine-readability.

--- a/pkg/wharfapi/build.go
+++ b/pkg/wharfapi/build.go
@@ -43,6 +43,7 @@ type ProjectStartBuild struct {
 	Stage       string `url:"stage"`
 	Branch      string `url:"branch,omitempty"`
 	Environment string `url:"environment,omitempty"`
+	Engine      string `url:"engine,omitempty"`
 }
 
 // GetBuildList filters builds based on the parameters by invoking the HTTP

--- a/pkg/wharfapi/engine.go
+++ b/pkg/wharfapi/engine.go
@@ -1,0 +1,17 @@
+package wharfapi
+
+import "github.com/iver-wharf/wharf-api-client-go/v2/pkg/model/response"
+
+// GetEngineList filters builds based on the parameters by invoking the HTTP
+// request:
+//  GET /api/build
+//
+// Added in wharf-api v5.1.0.
+func (c *Client) GetEngineList() (response.EngineList, error) {
+	if err := c.validateEndpointVersion(5, 1, 0); err != nil {
+		return response.EngineList{}, err
+	}
+	var list response.EngineList
+	err := c.getUnmarshal("/api/engine", nil, &list)
+	return list, err
+}


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Added `GET /api/engine` endpoint
- Added `?engine=...` query parameter to `POST /api/project/1/build` endpoint

## Motivation

Closes #44
