### PR TITLE
Fixed PUT /api/project/123/branch endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   field of `wharfapi.Client`. Now defaults to `80` for `HTTP` URLs, and `443`
   for `HTTPS`. (#48)
 
+- Fixed `UpdateProjectBranchList` using the wrong HTTP request & response
+  bodies. (#49)
+
 ## v2.2.0 (2022-05-02)
 
 - Added methods for execution engine: (#45)

--- a/pkg/wharfapi/branch.go
+++ b/pkg/wharfapi/branch.go
@@ -32,10 +32,21 @@ func (c *Client) UpdateProjectBranchList(projectID uint, branches []request.Bran
 	if err := c.validateEndpointVersion(5, 0, 0); err != nil {
 		return nil, err
 	}
-	var newBranches []response.Branch
+	body := request.BranchListUpdate{
+		Branches: make([]request.BranchUpdate, 0, len(branches)),
+	}
+	for _, b := range branches {
+		body.Branches = append(body.Branches, request.BranchUpdate{
+			Name: b.Name,
+		})
+		if b.Default {
+			body.DefaultBranch = b.Name
+		}
+	}
+	var response response.BranchList
 	path := fmt.Sprintf("/api/project/%d/branch", projectID)
-	err := c.putJSONUnmarshal(path, nil, branches, &newBranches)
-	return newBranches, err
+	err := c.putJSONUnmarshal(path, nil, body, &response)
+	return response.Branches, err
 }
 
 // GetProjectBranchList gets the branches for a project by invoking the HTTP


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Fixed `UpdateProjectBranchList` using the wrong HTTP request & response bodies.

## Motivation

The GitLab provider couldn't update branches :(
