### PR TITLE
Release v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v2.2.1 (WIP)
+## v2.2.1 (2022-05-10)
 
 - Fixed gRPC logs streaming failing if no port is specified in the `APIURL`
   field of `wharfapi.Client`. Now defaults to `80` for `HTTP` URLs, and `443`


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- Fixed gRPC logs streaming failing if no port is specified in the `APIURL` field of `wharfapi.Client`. Now defaults to `80` for `HTTP` URLs, and `443` for `HTTPS`. (#48)

- Fixed `UpdateProjectBranchList` using the wrong HTTP request & response bodies. (#49)

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
